### PR TITLE
add cancel action API

### DIFF
--- a/hawkbit/examples/polling.rs
+++ b/hawkbit/examples/polling.rs
@@ -74,6 +74,20 @@ async fn main() -> Result<()> {
                 .await?;
         }
 
+        if let Some(cancel_action) = reply.cancel_action() {
+            println!("Action to cancel: {}", cancel_action.id().await?);
+
+            cancel_action
+                .send_feedback(Execution::Proceeding, Finished::None, vec!["Cancelling"])
+                .await?;
+
+            cancel_action
+                .send_feedback(Execution::Closed, Finished::Success, vec![])
+                .await?;
+
+            println!("Action cancelled");
+        }
+
         let t = reply.polling_sleep()?;
         sleep(t).await;
     }

--- a/hawkbit/src/ddi.rs
+++ b/hawkbit/src/ddi.rs
@@ -13,6 +13,7 @@
 
 // FIXME: set link to hawbit/examples/polling.rs once we have the final public repo
 
+mod cancel_action;
 mod client;
 mod common;
 mod config_data;
@@ -20,6 +21,7 @@ mod deployment_base;
 mod feedback;
 mod poll;
 
+pub use cancel_action::CancelAction;
 pub use client::{Client, Error};
 pub use common::{Execution, Finished};
 pub use config_data::{ConfigRequest, Mode};

--- a/hawkbit/src/ddi/cancel_action.rs
+++ b/hawkbit/src/ddi/cancel_action.rs
@@ -1,0 +1,77 @@
+// Copyright 2021, Collabora Ltd.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// Cancelled operation
+
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::ddi::client::Error;
+use crate::ddi::common::{send_feedback_internal, Execution, Finished};
+
+/// A request from the server to cancel an update.
+///
+/// Call [`CancelAction::id()`] to retrieve the ID of the action to cancel.
+///
+/// Cancel actions need to be closed by sending feedback to the server using
+/// [`CancelAction::send_feedback`] with either
+/// [`Finished::Success`] or [`Finished::Failure`].
+#[derive(Debug)]
+pub struct CancelAction {
+    client: Client,
+    url: String,
+}
+
+impl CancelAction {
+    pub(crate) fn new(client: Client, url: String) -> Self {
+        Self { client, url }
+    }
+
+    /// Retrieve the id of the action to cancel.
+    pub async fn id(&self) -> Result<String, Error> {
+        let reply = self.client.get(&self.url).send().await?;
+        reply.error_for_status_ref()?;
+
+        let reply = reply.json::<CancelReply>().await?;
+        Ok(reply.cancel_action.stop_id)
+    }
+
+    /// Send feedback to server about this cancel action.
+    ///
+    /// # Arguments
+    /// * `execution`: status of the action execution.
+    /// * `finished`: defined status of the result. The action will be kept open on the server until the controller on the device reports either [`Finished::Success`] or [`Finished::Failure`].
+    /// * `details`: list of details message information.
+    pub async fn send_feedback(
+        &self,
+        execution: Execution,
+        finished: Finished,
+        details: Vec<&str>,
+    ) -> Result<(), Error> {
+        let id = self.id().await?;
+
+        send_feedback_internal::<bool>(
+            &self.client,
+            &self.url,
+            &id,
+            execution,
+            finished,
+            None,
+            details,
+        )
+        .await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CancelReply {
+    id: String,
+    #[serde(rename = "cancelAction")]
+    cancel_action: CancelActionReply,
+}
+
+#[derive(Debug, Deserialize)]
+struct CancelActionReply {
+    #[serde(rename = "stopId")]
+    stop_id: String,
+}

--- a/hawkbit/src/ddi/common.rs
+++ b/hawkbit/src/ddi/common.rs
@@ -63,16 +63,10 @@ pub(crate) async fn send_feedback_internal<T: Serialize>(
 ) -> Result<(), Error> {
     let mut url: Url = url.parse()?;
     {
-        match url.path_segments_mut() {
-            Err(_) => {
-                return Err(Error::ParseUrlError(
-                    url::ParseError::SetHostOnCannotBeABaseUrl,
-                ))
-            }
-            Ok(mut paths) => {
-                paths.push("feedback");
-            }
-        }
+        let mut paths = url
+            .path_segments_mut()
+            .map_err(|_| url::ParseError::SetHostOnCannotBeABaseUrl)?;
+        paths.push("feedback");
     }
     url.set_query(None);
 

--- a/hawkbit/src/ddi/feedback.rs
+++ b/hawkbit/src/ddi/feedback.rs
@@ -22,6 +22,7 @@ struct Status<T: Serialize> {
 #[derive(Debug, Serialize)]
 pub struct ResultT<T: Serialize> {
     finished: Finished,
+    #[serde(skip_serializing_if = "Option::is_none")]
     progress: Option<T>,
 }
 

--- a/hawkbit/src/ddi/poll.rs
+++ b/hawkbit/src/ddi/poll.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use reqwest::Client;
 use serde::Deserialize;
 
+use crate::ddi::cancel_action::CancelAction;
 use crate::ddi::client::Error;
 use crate::ddi::common::Link;
 use crate::ddi::config_data::ConfigRequest;
@@ -72,6 +73,17 @@ impl Reply {
                 .deployment_base
                 .as_ref()
                 .map(|l| UpdatePreFetch::new(self.client.clone(), l.to_string())),
+            None => None,
+        }
+    }
+
+    /// Returns pending cancel action, if any.
+    pub fn cancel_action(&self) -> Option<CancelAction> {
+        match &self.reply.links {
+            Some(links) => links
+                .cancel_action
+                .as_ref()
+                .map(|l| CancelAction::new(self.client.clone(), l.to_string())),
             None => None,
         }
     }

--- a/hawkbit/tests/tests.rs
+++ b/hawkbit/tests/tests.rs
@@ -219,7 +219,7 @@ async fn deployment() {
 }
 
 #[tokio::test]
-async fn send_feedback() {
+async fn send_deployment_feedback() {
     init();
 
     let server = ServerBuilder::default().build();
@@ -233,7 +233,7 @@ async fn send_feedback() {
     let update = update.fetch().await.expect("failed to fetch update info");
 
     // Send feedback without progress
-    let mut mock = target.expect_feedback(
+    let mut mock = target.expect_deployment_feedback(
         &deploy_id,
         Execution::Proceeding,
         Finished::None,
@@ -250,7 +250,7 @@ async fn send_feedback() {
     mock.delete();
 
     // Send feedback with progress
-    let mut mock = target.expect_feedback(
+    let mut mock = target.expect_deployment_feedback(
         &deploy_id,
         Execution::Closed,
         Finished::Success,

--- a/hawkbit_mock/src/ddi.rs
+++ b/hawkbit_mock/src/ddi.rs
@@ -343,20 +343,30 @@ impl Target {
         progress: Option<serde_json::Value>,
         details: Vec<&str>,
     ) -> MockRef<'_> {
-        let progress = progress.unwrap_or(serde_json::Value::Null);
-
         self.server.mock(|when, then| {
-            let expected = json!({
-                "id": deployment_id,
-                "status": {
-                    "result": {
-                        "progress": progress,
-                        "finished": finished
+            let expected = match progress {
+                Some(progress) => json!({
+                    "id": deployment_id,
+                    "status": {
+                        "result": {
+                            "progress": progress,
+                            "finished": finished
+                        },
+                        "execution": execution,
+                        "details": details,
                     },
-                    "execution": execution,
-                    "details": details,
-                },
-            });
+                }),
+                None => json!({
+                    "id": deployment_id,
+                    "status": {
+                        "result": {
+                            "finished": finished
+                        },
+                        "execution": execution,
+                        "details": details,
+                    },
+                }),
+            };
 
             when.method(POST)
                 .path(format!(

--- a/hawkbit_mock/src/ddi.rs
+++ b/hawkbit_mock/src/ddi.rs
@@ -310,7 +310,7 @@ impl Target {
         self.update_poll();
     }
 
-    /// Configure the server to expect feedback from the target.
+    /// Configure the server to expect deployment feedback from the target.
     /// One can then check the feedback has actually been received using
     /// `hits()` on the returned object.
     ///
@@ -323,7 +323,7 @@ impl Target {
     ///
     /// let server = ServerBuilder::default().build();
     /// let target = server.add_target("Target1");
-    /// let mut mock = target.expect_feedback(
+    /// let mut mock = target.expect_deployment_feedback(
     ///         "10",
     ///         Execution::Closed,
     ///         Finished::Success,
@@ -335,7 +335,7 @@ impl Target {
     /// //Client send the feedback
     /// //assert_eq!(mock.hits(), 1);
     /// ```
-    pub fn expect_feedback(
+    pub fn expect_deployment_feedback(
         &self,
         deployment_id: &str,
         execution: Execution,


### PR DESCRIPTION
 We can now check if hawkbit returned a cancel action when polling and send feedback about it.