### PR TITLE
Add 'use-rustls' and 'native-tls' features

### DIFF
--- a/hawkbit/Cargo.toml
+++ b/hawkbit/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/collabora/hawkbit-rs"
 documentation = "https://docs.rs/hawkbit_mock/"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.11", default-features=false, features = ["json", "stream"] }
 tokio = { version = "1.1", features = ["time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -37,6 +37,11 @@ tempdir = "0.3"
 assert_matches = "1.4"
 
 [features]
+default = ["native-tls"]
+
+native-tls = ["reqwest/default-tls"]
+use-rustls = ["reqwest/rustls-tls-manual-roots"]
+
 hash-digest= ["digest", "generic-array"]
 hash-md5 = ["md-5", "hash-digest"]
 hash-sha1 = ["sha-1", "hash-digest"]

--- a/hawkbit/Cargo.toml
+++ b/hawkbit/Cargo.toml
@@ -40,7 +40,7 @@ assert_matches = "1.4"
 default = ["native-tls"]
 
 native-tls = ["reqwest/default-tls"]
-use-rustls = ["reqwest/rustls-tls-manual-roots"]
+use-rustls = ["reqwest/rustls-tls"]
 
 hash-digest= ["digest", "generic-array"]
 hash-md5 = ["md-5", "hash-digest"]


### PR DESCRIPTION
This PR introduces two new cargo features:
- (default) `native-tls` which enables the reqwest `default-tls` feature -> this configuration is the same as the previous default. Therefore no change in default behvior is introduced.
- `use-rustls` replaces the `default-tls` feature with the `rustls-tls-manual-roots` reqwest feature. This removes the openssl dependency and uses the rustls ssl implemention.

This change is useful, because for some use cases it may not be optimal to depend on the openssl system lib. For example cross-compilation.

## Caveats
The `hawkbit` lib lists the `hawkbit_mock` lib as a dev dependency. This is proplematic, because it depends on the `httpmock` lib, which has no option to turn off `native-tls`.
Even though it is only a test dependency, running `cargo build` will still fail if openssl is not available on the system. -> Open issue and workaround (requires nightly) here https://github.com/rust-lang/cargo/issues/5133.

```
openssl-sys v0.9.83
├── curl v0.4.44
│   └── isahc v1.7.2
│       └── httpmock v0.5.8
│           └── hawkbit_mock v0.6.0 (/hawkbit-rs/hawkbit_mock)
│               [dev-dependencies]
│               └── hawkbit v0.6.0 (/hawkbit-rs/hawkbit)
│                   └── hawkbit_mock v0.6.0 (/hawkbit-rs/hawkbit_mock) (*)
``` 