### PR TITLE
Support more DDI status.execution types and add action id access method

### DIFF
--- a/hawkbit/src/ddi/common.rs
+++ b/hawkbit/src/ddi/common.rs
@@ -32,6 +32,10 @@ pub enum Execution {
     Proceeding,
     /// This is send by the target as confirmation of a cancellation request by the update server.
     Canceled,
+    /// This can be used by the target to inform that it will start downloading
+    Download,
+    /// This can be used by the target to inform that it finished downloading
+    Downloaded,
     /// This can be used by the target to inform that it scheduled on the action.
     Scheduled,
     /// This is send by the target in case an update of a cancellation is rejected, i.e. cannot be fulfilled at this point in time.

--- a/hawkbit/src/ddi/deployment_base.rs
+++ b/hawkbit/src/ddi/deployment_base.rs
@@ -223,6 +223,14 @@ impl Update {
         Self { client, info, url }
     }
 
+    /// The id of the deployment action.
+    ///
+    /// This is relevant to extract to make sure upcoming requests are relevant
+    /// for the pending action and report error if it is not.
+    pub fn id(&self) -> String {
+        self.info.id.clone()
+    }
+
     /// Handling for the download part of the provisioning process.
     pub fn download_type(&self) -> Type {
         self.info.deployment.download


### PR DESCRIPTION
This PR introduces two small additions to extend the functionality:
- Support for two new DDI status.execution types. These can be used for more fine-grained feedback to hawkBit.
- A method to get action id of an Update.

Both changes are unobtrusive but adds functionality important to our workflow.