### PR TITLE
feat: add support for hawkbit consent flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,10 @@ jobs:
           command: test
           args: --all-features --no-fail-fast
         env:
-          RUSTFLAGS: "-Zinstrument-coverage"
+          RUSTFLAGS: "-C instrument-coverage"
           LLVM_PROFILE_FILE: "hawkbitrs-%p-%m.profraw"
       - name: Install grcov
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+        run: cargo install grcov
       - name: Run grcov
         run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "hawkbit/examples/*" --ignore "*target*" -o coverage.lcov
       - name: Upload coverage to Codecov

--- a/hawkbit/Cargo.toml
+++ b/hawkbit/Cargo.toml
@@ -11,19 +11,18 @@ repository = "https://github.com/collabora/hawkbit-rs"
 documentation = "https://docs.rs/hawkbit_mock/"
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 tokio = { version = "1.1", features = ["time", "fs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 url = "2.2"
-strum = { version = "0.21", features = ["derive"] }
+strum = { version = "0.27", features = ["derive"] }
 cfg-if = "1.0"
-digest = { version = "0.9", optional = true }
-md-5 = { version = "0.9", optional = true }
-sha-1 = { version = "0.9", optional = true }
-sha2 = { version = "0.9", optional = true }
-generic-array = {version = "0.14", optional = true }
+digest = { version = "0.10", optional = true }
+md-5 = { version = "0.10", optional = true }
+sha-1 = { version = "0.10", optional = true }
+sha2 = { version = "0.10", optional = true }
 futures = "0.3"
 bytes = "1.0"
 
@@ -32,12 +31,12 @@ hawkbit_mock = { path = "../hawkbit_mock/" }
 structopt = "0.3"
 anyhow = "1.0"
 log = "0.4"
-env_logger = "0.8"
+env_logger = "0.11"
 tempdir = "0.3"
 assert_matches = "1.4"
 
 [features]
-hash-digest= ["digest", "generic-array"]
+hash-digest= ["digest"]
 hash-md5 = ["md-5", "hash-digest"]
 hash-sha1 = ["sha-1", "hash-digest"]
 hash-sha256 = ["sha2", "hash-digest"]

--- a/hawkbit/src/ddi.rs
+++ b/hawkbit/src/ddi.rs
@@ -32,6 +32,6 @@ pub use deployment_base::{
     Artifact, Chunk, DownloadedArtifact, MaintenanceWindow, Type, Update, UpdatePreFetch,
 };
 pub use confirmation_base::{
-    ConfirmationRequest, ConfirmationInfo,
+    ConfirmationRequest, ConfirmationInfo, ConfirmationResponse,
 };
 pub use poll::Reply;

--- a/hawkbit/src/ddi.rs
+++ b/hawkbit/src/ddi.rs
@@ -32,6 +32,6 @@ pub use deployment_base::{
     Artifact, Chunk, DownloadedArtifact, MaintenanceWindow, Type, Update, UpdatePreFetch,
 };
 pub use confirmation_base::{
-    ConfirmationRequest,
+    ConfirmationRequest, ConfirmationInfo,
 };
 pub use poll::Reply;

--- a/hawkbit/src/ddi.rs
+++ b/hawkbit/src/ddi.rs
@@ -18,6 +18,7 @@ mod client;
 mod common;
 mod config_data;
 mod deployment_base;
+mod confirmation_base;
 mod feedback;
 mod poll;
 
@@ -29,5 +30,8 @@ pub use config_data::{ConfigRequest, Mode};
 pub use deployment_base::ChecksumType;
 pub use deployment_base::{
     Artifact, Chunk, DownloadedArtifact, MaintenanceWindow, Type, Update, UpdatePreFetch,
+};
+pub use confirmation_base::{
+    ConfirmationRequest,
 };
 pub use poll::Reply;

--- a/hawkbit/src/ddi.rs
+++ b/hawkbit/src/ddi.rs
@@ -17,8 +17,8 @@ mod cancel_action;
 mod client;
 mod common;
 mod config_data;
-mod deployment_base;
 mod confirmation_base;
+mod deployment_base;
 mod feedback;
 mod poll;
 
@@ -26,12 +26,10 @@ pub use cancel_action::CancelAction;
 pub use client::{Client, Error};
 pub use common::{Execution, Finished};
 pub use config_data::{ConfigRequest, Mode};
+pub use confirmation_base::{ConfirmationInfo, ConfirmationRequest, ConfirmationResponse};
 #[cfg(feature = "hash-digest")]
 pub use deployment_base::ChecksumType;
 pub use deployment_base::{
     Artifact, Chunk, DownloadedArtifact, MaintenanceWindow, Type, Update, UpdatePreFetch,
-};
-pub use confirmation_base::{
-    ConfirmationRequest, ConfirmationInfo, ConfirmationResponse,
 };
 pub use poll::Reply;

--- a/hawkbit/src/ddi/cancel_action.rs
+++ b/hawkbit/src/ddi/cancel_action.rs
@@ -63,6 +63,7 @@ impl CancelAction {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 struct CancelReply {
     id: String,

--- a/hawkbit/src/ddi/common.rs
+++ b/hawkbit/src/ddi/common.rs
@@ -73,7 +73,7 @@ pub(crate) async fn send_feedback_internal<T: Serialize>(
     let details = details.iter().map(|m| m.to_string()).collect();
     let feedback = Feedback::new(id, execution, finished, progress, details);
 
-    let reply = client.post(&url.to_string()).json(&feedback).send().await?;
+    let reply = client.post(url.to_string()).json(&feedback).send().await?;
     reply.error_for_status()?;
 
     Ok(())

--- a/hawkbit/src/ddi/common.rs
+++ b/hawkbit/src/ddi/common.rs
@@ -38,6 +38,10 @@ pub enum Execution {
     Rejected,
     /// This can be used by the target to inform that it continued to work on the action.
     Resumed,
+    /// This can be used to inform the server that the target finished downloading the artifact.
+    Downloaded,
+    /// This can be used to inform the server that the target is downloading the artifact.
+    Download,
 }
 
 #[derive(Debug, Serialize)]

--- a/hawkbit/src/ddi/confirmation_base.rs
+++ b/hawkbit/src/ddi/confirmation_base.rs
@@ -160,6 +160,7 @@ pub enum ConfirmationResponse {
 pub struct Confirmation {
     confirmation: ConfirmationResponse,
     code: i32,
+    details: Vec<String>,
 }
 
 impl Confirmation {
@@ -167,6 +168,7 @@ impl Confirmation {
         Self {
             confirmation,
             code,
+            details: vec![],
         }
     }
 }

--- a/hawkbit/src/ddi/confirmation_base.rs
+++ b/hawkbit/src/ddi/confirmation_base.rs
@@ -5,9 +5,10 @@ use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 
 use crate::ddi::client::Error;
-use crate::ddi::deployment_base::{Deployment, Chunk};
+use crate::ddi::deployment_base::{Chunk, Deployment};
 
 #[derive(Debug)]
+#[allow(dead_code)]
 /// A pending confirmation whose details have not been retrieved yet.
 ///
 /// Call [`ConfirmationRequest::fetch()`] to retrieve the details from server.
@@ -19,7 +20,11 @@ pub struct ConfirmationRequest {
 
 impl ConfirmationRequest {
     pub(crate) fn new(client: Client, url: String) -> Self {
-        Self { client, url, details: vec![] }
+        Self {
+            client,
+            url,
+            details: vec![],
+        }
     }
 
     /// confirm the confirmation request. The server should then proceed with the update and make a deploymentBase available.
@@ -36,8 +41,9 @@ impl ConfirmationRequest {
         }
         url.set_query(None);
 
-        let reply = self.client
-            .post(&url.to_string())
+        let reply = self
+            .client
+            .post(url.to_string())
             .json(&confirmation)
             .send()
             .await?;
@@ -59,8 +65,9 @@ impl ConfirmationRequest {
         }
         url.set_query(None);
 
-        let reply = self.client
-            .post(&url.to_string())
+        let reply = self
+            .client
+            .post(url.to_string())
             .json(&confirmation)
             .send()
             .await?;
@@ -74,7 +81,10 @@ impl ConfirmationRequest {
         reply.error_for_status_ref()?;
 
         let reply: Reply = reply.json().await?;
-        Ok(ConfirmationInfo {reply, client: self.client.clone()})
+        Ok(ConfirmationInfo {
+            reply,
+            client: self.client.clone(),
+        })
     }
 
     /// The metadata of all chunks of the update.
@@ -95,8 +105,7 @@ impl ConfirmationRequest {
         // collect all metadata of each chunk
         let metadata = chunks
             .iter()
-            .map(|c| c.metadata().collect::<Vec<(&str, &str)>>())
-            .flatten()
+            .flat_map(|c| c.metadata().collect::<Vec<(&str, &str)>>())
             .map(|(k, v): (&str, &str)| (k.to_string(), v.to_string()))
             .collect();
 
@@ -126,8 +135,7 @@ impl ConfirmationInfo {
         // collect all metadata of each chunk
         let metadata = chunks
             .iter()
-            .map(|c| c.metadata().collect::<Vec<(&str, &str)>>())
-            .flatten()
+            .flat_map(|c| c.metadata().collect::<Vec<(&str, &str)>>())
             .map(|(k, v): (&str, &str)| (k.to_string(), v.to_string()))
             .collect();
 
@@ -142,8 +150,8 @@ impl ConfirmationInfo {
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Reply {
-     id: String,
-     confirmation: Deployment,
+    id: String,
+    confirmation: Deployment,
 }
 
 /// The response to a confirmation request.

--- a/hawkbit/src/ddi/confirmation_base.rs
+++ b/hawkbit/src/ddi/confirmation_base.rs
@@ -1,0 +1,136 @@
+// Copyright 2025, Liebherr Digital Development Center GmbH.
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use reqwest::{Client, Url};
+use serde::{Deserialize, Serialize};
+
+use crate::ddi::client::Error;
+use crate::ddi::deployment_base::{Deployment, Chunk};
+
+#[derive(Debug)]
+/// A pending confirmation whose details have not been retrieved yet.
+///
+/// Call [`ConfirmationRequest::fetch()`] to retrieve the details from server.
+pub struct ConfirmationRequest {
+    client: Client,
+    url: String,
+    details: Vec<String>,
+}
+
+impl ConfirmationRequest {
+    pub(crate) fn new(client: Client, url: String) -> Self {
+        Self { client, url, details: vec![] }
+    }
+
+    /// confirm the confirmation request. The server should then proceed with the update and make a deploymentBase available.
+    pub async fn confirm(self) -> Result<(), Error> {
+        let confirmation = Confirmation::new(ConfirmationResponse::Confirmed, 1);
+
+        // get feedback url
+        let mut url: Url = self.url.parse()?;
+        {
+            let mut paths = url
+                .path_segments_mut()
+                .map_err(|_| url::ParseError::SetHostOnCannotBeABaseUrl)?;
+            paths.push("feedback");
+        }
+        url.set_query(None);
+
+        let reply = self.client
+            .post(&url.to_string())
+            .json(&confirmation)
+            .send()
+            .await?;
+        reply.error_for_status_ref()?;
+        Ok(())
+    }
+
+    /// decline the confirmation request. This will not change the status on the server and the same confirmation request will be received on the next poll.
+    pub async fn decline(self) -> Result<(), Error> {
+        let confirmation = Confirmation::new(ConfirmationResponse::Denied, -1);
+
+        // get feedback url
+        let mut url: Url = self.url.parse()?;
+        {
+            let mut paths = url
+                .path_segments_mut()
+                .map_err(|_| url::ParseError::SetHostOnCannotBeABaseUrl)?;
+            paths.push("feedback");
+        }
+        url.set_query(None);
+
+        let reply = self.client
+            .post(&url.to_string())
+            .json(&confirmation)
+            .send()
+            .await?;
+        reply.error_for_status_ref()?;
+        Ok(())
+    }
+
+    /// Fetch the details of the update to be confirmed
+    async fn update_info(&self) -> Result<Reply, Error> {
+        let reply = self.client.get(&self.url).send().await?;
+        reply.error_for_status_ref()?;
+
+        let reply: Reply = reply.json().await?;
+        Ok(reply)
+    }
+
+    /// The metadata of all chunks of the update.
+    pub async fn metadata(&self) -> Result<Vec<(String, String)>, Error> {
+        let client = self.client.clone();
+
+        // get update information from the server
+        let update = self.update_info().await?;
+
+        // get all chunks of the update
+        let chunks: Vec<Chunk> = update
+            .confirmation
+            .chunks
+            .iter()
+            .map(move |c| Chunk::new(c, client.clone()))
+            .collect();
+
+        // collect all metadata of each chunk
+        let metadata = chunks
+            .iter()
+            .map(|c| c.metadata().collect::<Vec<(&str, &str)>>())
+            .flatten()
+            .map(|(k, v): (&str, &str)| (k.to_string(), v.to_string()))
+            .collect();
+
+        Ok(metadata)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct Reply {
+     id: String,
+     confirmation: Deployment,
+}
+
+/// The response to a confirmation request.
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum ConfirmationResponse {
+    /// Proceed with the download
+    Confirmed,
+    /// Decline the confirmation and do not update
+    Denied,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Confirmation {
+    confirmation: ConfirmationResponse,
+    code: i32,
+}
+
+impl Confirmation {
+    pub fn new(confirmation: ConfirmationResponse, code: i32) -> Self {
+        Self {
+            confirmation,
+            code,
+        }
+    }
+}

--- a/hawkbit/src/ddi/deployment_base.rs
+++ b/hawkbit/src/ddi/deployment_base.rs
@@ -538,8 +538,8 @@ cfg_if::cfg_if! {
         struct DownloadHasher<T>
         where
             T: Digest,
-            <T as Digest>::OutputSize: core::ops::Add,
-            <<T as Digest>::OutputSize as core::ops::Add>::Output: generic_array::ArrayLength<u8>,
+            <T as digest::OutputSizeUser>::OutputSize: core::ops::Add,
+            <<T as digest::OutputSizeUser>::OutputSize as core::ops::Add>::Output: digest::generic_array::ArrayLength<u8>
         {
             hasher: T,
             expected: String,
@@ -549,8 +549,8 @@ cfg_if::cfg_if! {
         impl<T> DownloadHasher<T>
         where
             T: Digest,
-            <T as Digest>::OutputSize: core::ops::Add,
-            <<T as Digest>::OutputSize as core::ops::Add>::Output: generic_array::ArrayLength<u8>
+            <T as digest::OutputSizeUser>::OutputSize: core::ops::Add,
+            <<T as digest::OutputSizeUser>::OutputSize as core::ops::Add>::Output: digest::generic_array::ArrayLength<u8>
         {
             fn update(&mut self, data: impl AsRef<[u8]>) {
                 self.hasher.update(data);
@@ -603,8 +603,8 @@ cfg_if::cfg_if! {
         struct DownloadStreamHash<T>
         where
             T: Digest,
-            <T as Digest>::OutputSize: core::ops::Add,
-            <<T as Digest>::OutputSize as core::ops::Add>::Output: generic_array::ArrayLength<u8>,
+            <T as digest::OutputSizeUser>::OutputSize: core::ops::Add,
+            <<T as digest::OutputSizeUser>::OutputSize as core::ops::Add>::Output: digest::generic_array::ArrayLength<u8>
         {
             stream: Box<dyn Stream<Item = Result<Bytes, Error>> + Unpin + Send + Sync>,
             hasher: DownloadHasher<T>,
@@ -613,8 +613,8 @@ cfg_if::cfg_if! {
         impl<T> Stream for DownloadStreamHash<T>
         where
             T: Digest,
-            <T as Digest>::OutputSize: core::ops::Add,
-            <<T as Digest>::OutputSize as core::ops::Add>::Output: generic_array::ArrayLength<u8>,
+            <T as digest::OutputSizeUser>::OutputSize: core::ops::Add,
+            <<T as digest::OutputSizeUser>::OutputSize as core::ops::Add>::Output: digest::generic_array::ArrayLength<u8>,
             T: Unpin,
             T: Clone,
         {
@@ -661,9 +661,10 @@ impl<'a> DownloadedArtifact {
     #[cfg(feature = "hash-digest")]
     async fn hash<T>(&self, mut hasher: DownloadHasher<T>) -> Result<(), Error>
     where
-        T: Digest,
-        <T as Digest>::OutputSize: core::ops::Add,
-        <<T as Digest>::OutputSize as core::ops::Add>::Output: generic_array::ArrayLength<u8>,
+        T: digest::Digest,
+        <T as digest::OutputSizeUser>::OutputSize: core::ops::Add,
+        <<T as digest::OutputSizeUser>::OutputSize as core::ops::Add>::Output:
+            digest::generic_array::ArrayLength<u8>,
     {
         use tokio::io::AsyncReadExt;
 

--- a/hawkbit/src/ddi/deployment_base.rs
+++ b/hawkbit/src/ddi/deployment_base.rs
@@ -44,6 +44,7 @@ impl UpdatePreFetch {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct Reply {
     id: String,
     deployment: Deployment,
@@ -108,6 +109,7 @@ struct ArtifactInternal {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+#[allow(dead_code)]
 struct Hashes {
     sha1: String,
     md5: String,
@@ -190,6 +192,7 @@ impl<'de> Deserialize<'de> for Links {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct Download {
     content: Link,
     md5sum: Option<Link>,
@@ -204,6 +207,7 @@ struct Links {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct ActionHistory {
     status: String,
     #[serde(default)]
@@ -239,7 +243,7 @@ impl Update {
     }
 
     /// An iterator on all the software chunks of the update.
-    pub fn chunks(&self) -> impl Iterator<Item = Chunk> {
+    pub fn chunks(&self) -> impl Iterator<Item = Chunk<'_>> {
         let client = self.client.clone();
 
         self.info
@@ -336,7 +340,7 @@ impl<'a> Chunk<'a> {
     }
 
     /// An iterator on all the artifacts of the chunk.
-    pub fn artifacts(&self) -> impl Iterator<Item = Artifact> {
+    pub fn artifacts(&self) -> impl Iterator<Item = Artifact<'_>> {
         let client = self.client.clone();
 
         self.chunk
@@ -396,14 +400,10 @@ impl<'a> Artifact<'a> {
             .links
             .https
             .as_ref()
-            .or_else(|| self.artifact.links.http.as_ref())
+            .or(self.artifact.links.http.as_ref())
             .expect("Missing content link in for artifact");
 
-        let resp = self
-            .client
-            .get(&download.content.to_string())
-            .send()
-            .await?;
+        let resp = self.client.get(download.content.to_string()).send().await?;
 
         resp.error_for_status_ref()?;
         Ok(resp)
@@ -503,6 +503,7 @@ impl<'a> Artifact<'a> {
 }
 
 /// A downloaded file part of a [`Chunk`].
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct DownloadedArtifact {
     file: PathBuf,
@@ -648,7 +649,7 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<'a> DownloadedArtifact {
+impl DownloadedArtifact {
     fn new(file: PathBuf, hashes: Hashes) -> Self {
         Self { file, hashes }
     }

--- a/hawkbit/src/ddi/deployment_base.rs
+++ b/hawkbit/src/ddi/deployment_base.rs
@@ -53,12 +53,12 @@ struct Reply {
 }
 
 #[derive(Debug, Deserialize)]
-struct Deployment {
+pub(crate) struct Deployment {
     download: Type,
     update: Type,
     #[serde(rename = "maintenanceWindow")]
     maintenance_window: Option<MaintenanceWindow>,
-    chunks: Vec<ChunkInternal>,
+    pub(crate) chunks: Vec<ChunkInternal>,
 }
 
 /// How the download or update should be processed by the target.
@@ -84,7 +84,7 @@ pub enum MaintenanceWindow {
 }
 
 #[derive(Debug, Deserialize)]
-struct ChunkInternal {
+pub(crate) struct ChunkInternal {
     #[serde(default)]
     metadata: Vec<Metadata>,
     part: String,
@@ -320,7 +320,7 @@ pub struct Chunk<'a> {
 }
 
 impl<'a> Chunk<'a> {
-    fn new(chunk: &'a ChunkInternal, client: Client) -> Self {
+    pub(crate) fn new(chunk: &'a ChunkInternal, client: Client) -> Self {
         Self { chunk, client }
     }
 

--- a/hawkbit/src/ddi/poll.rs
+++ b/hawkbit/src/ddi/poll.rs
@@ -12,6 +12,7 @@ use crate::ddi::cancel_action::CancelAction;
 use crate::ddi::client::Error;
 use crate::ddi::common::Link;
 use crate::ddi::config_data::ConfigRequest;
+use crate::ddi::confirmation_base::ConfirmationRequest;
 use crate::ddi::deployment_base::UpdatePreFetch;
 
 #[derive(Debug, Deserialize)]
@@ -34,6 +35,8 @@ pub struct Links {
     config_data: Option<Link>,
     #[serde(rename = "deploymentBase")]
     deployment_base: Option<Link>,
+    #[serde(rename = "confirmationBase")]
+    confirmation_base: Option<Link>,
     #[serde(rename = "cancelAction")]
     cancel_action: Option<Link>,
 }
@@ -73,6 +76,17 @@ impl Reply {
                 .deployment_base
                 .as_ref()
                 .map(|l| UpdatePreFetch::new(self.client.clone(), l.to_string())),
+            None => None,
+        }
+    }
+
+    /// Returns pending confirmations, if any.
+    pub fn confirmation_base(&self) -> Option<ConfirmationRequest> {
+        match &self.reply.links {
+            Some(links) => links
+                .confirmation_base
+                .as_ref()
+                .map(|l| ConfirmationRequest::new(self.client.clone(), l.to_string())),
             None => None,
         }
     }

--- a/hawkbit/tests/tests.rs
+++ b/hawkbit/tests/tests.rs
@@ -240,13 +240,13 @@ async fn send_deployment_feedback() {
         None,
         vec!["Downloading"],
     );
-    assert_eq!(mock.hits(), 0);
+    assert_eq!(mock.calls(), 0);
 
     update
         .send_feedback(Execution::Proceeding, Finished::None, vec!["Downloading"])
         .await
         .expect("Failed to send feedback");
-    assert_eq!(mock.hits(), 1);
+    assert_eq!(mock.calls(), 1);
     mock.delete();
 
     // Send feedback with progress
@@ -257,7 +257,7 @@ async fn send_deployment_feedback() {
         Some(json!({"awesome": true})),
         vec!["Done"],
     );
-    assert_eq!(mock.hits(), 0);
+    assert_eq!(mock.calls(), 0);
 
     #[derive(Serialize)]
     struct Progress {
@@ -274,7 +274,7 @@ async fn send_deployment_feedback() {
         )
         .await
         .expect("Failed to send feedback");
-    assert_eq!(mock.hits(), 1);
+    assert_eq!(mock.calls(), 1);
     mock.delete();
 }
 
@@ -489,12 +489,12 @@ async fn cancel_action() {
         Finished::None,
         vec!["Cancelling"],
     );
-    assert_eq!(mock.hits(), 0);
+    assert_eq!(mock.calls(), 0);
 
     cancel_action
         .send_feedback(Execution::Proceeding, Finished::None, vec!["Cancelling"])
         .await
         .expect("Failed to send feedback");
-    assert_eq!(mock.hits(), 1);
+    assert_eq!(mock.calls(), 1);
     mock.delete();
 }

--- a/hawkbit_mock/Cargo.toml
+++ b/hawkbit_mock/Cargo.toml
@@ -12,6 +12,6 @@ documentation = "https://docs.rs/hawkbit/"
 
 [dependencies]
 hawkbit = { version = "0.6.0", path = "../hawkbit/" }
-httpmock = "0.5.4"
+httpmock = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/hawkbit_mock/src/ddi.rs
+++ b/hawkbit_mock/src/ddi.rs
@@ -30,7 +30,7 @@ use std::{
 
 use httpmock::{
     Method::{GET, POST, PUT},
-    MockRef, MockRefExt, MockServer,
+    Mock, MockExt, MockServer,
 };
 use serde_json::{json, Map, Value};
 
@@ -178,7 +178,7 @@ impl Target {
             self.cancel_action.borrow().as_ref(),
         ));
 
-        let mut old = MockRef::new(old, &self.server);
+        let mut old = Mock::new(old, &self.server);
         old.delete();
     }
 
@@ -349,7 +349,7 @@ impl Target {
         finished: Finished,
         progress: Option<serde_json::Value>,
         details: Vec<&str>,
-    ) -> MockRef<'_> {
+    ) -> Mock<'_> {
         self.server.mock(|when, then| {
             let expected = match progress {
                 Some(progress) => json!({
@@ -471,7 +471,7 @@ impl Target {
         execution: Execution,
         finished: Finished,
         details: Vec<&str>,
-    ) -> MockRef<'_> {
+    ) -> Mock<'_> {
         self.server.mock(|when, then| {
             let expected = json!({
                 "id": cancel_id,
@@ -499,14 +499,14 @@ impl Target {
 
     /// Return the number of times the poll API has been called by the client.
     pub fn poll_hits(&self) -> usize {
-        let mock = MockRef::new(self.poll.get(), &self.server);
+        let mock = Mock::new(self.poll.get(), &self.server);
         mock.hits()
     }
 
     /// Return the number of times the target configuration has been uploaded by the client.
     pub fn config_data_hits(&self) -> usize {
         self.config_data.borrow().as_ref().map_or(0, |m| {
-            let mock = MockRef::new(m.mock, &self.server);
+            let mock = Mock::new(m.mock, &self.server);
             mock.hits()
         })
     }
@@ -514,7 +514,7 @@ impl Target {
     /// Return the number of times the deployment details have been fetched by the client.
     pub fn deployment_hits(&self) -> usize {
         self.deployment.borrow().as_ref().map_or(0, |m| {
-            let mock = MockRef::new(m.mock, &self.server);
+            let mock = Mock::new(m.mock, &self.server);
             mock.hits()
         })
     }
@@ -522,7 +522,7 @@ impl Target {
     /// Return the number of times the cancel action URL has been fetched by the client.
     pub fn cancel_action_hits(&self) -> usize {
         self.cancel_action.borrow().as_ref().map_or(0, |m| {
-            let mock = MockRef::new(m.mock, &self.server);
+            let mock = Mock::new(m.mock, &self.server);
             mock.hits()
         })
     }
@@ -536,7 +536,7 @@ struct PendingAction {
 
 impl Drop for PendingAction {
     fn drop(&mut self) {
-        let mut mock = MockRef::new(self.mock, &self.server);
+        let mut mock = Mock::new(self.mock, &self.server);
         mock.delete();
     }
 }

--- a/hawkbit_mock/src/ddi.rs
+++ b/hawkbit_mock/src/ddi.rs
@@ -124,6 +124,7 @@ impl Target {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn create_poll(
         server: &MockServer,
         tenant: &str,
@@ -157,7 +158,7 @@ impl Target {
         let mock = server.mock(|when, then| {
             when.method(GET)
                 .path(format!("/{}/controller/v1/{}", tenant, name))
-                .header("Authorization", &format!("TargetToken {}", key));
+                .header("Authorization", format!("TargetToken {}", key));
 
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -221,7 +222,7 @@ impl Target {
             when.method(PUT)
                 .path(format!("/DEFAULT/controller/v1/{}/configData", self.name))
                 .header("Content-Type", "application/json")
-                .header("Authorization", &format!("TargetToken {}", self.key))
+                .header("Authorization", format!("TargetToken {}", self.key))
                 .json_body(expected_config_data);
 
             then.status(200);
@@ -285,7 +286,7 @@ impl Target {
                     "/DEFAULT/controller/v1/{}/deploymentBase/{}",
                     self.name, deploy.id
                 ))
-                .header("Authorization", &format!("TargetToken {}", self.key));
+                .header("Authorization", format!("TargetToken {}", self.key));
 
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -301,7 +302,7 @@ impl Target {
                 self.server.mock(|when, then| {
                     when.method(GET)
                         .path(path)
-                        .header("Authorization", &format!("TargetToken {}", self.key));
+                        .header("Authorization", format!("TargetToken {}", self.key));
 
                     then.status(200).body_from_file(artifact.to_str().unwrap());
                 });
@@ -380,7 +381,7 @@ impl Target {
                     "/{}/controller/v1/{}/deploymentBase/{}/feedback",
                     self.tenant, self.name, deployment_id
                 ))
-                .header("Authorization", &format!("TargetToken {}", self.key))
+                .header("Authorization", format!("TargetToken {}", self.key))
                 .header("Content-Type", "application/json")
                 .json_body(expected);
 
@@ -423,7 +424,7 @@ impl Target {
                     "/DEFAULT/controller/v1/{}/cancelAction/{}",
                     self.name, id
                 ))
-                .header("Authorization", &format!("TargetToken {}", self.key));
+                .header("Authorization", format!("TargetToken {}", self.key));
 
             then.status(200)
                 .header("Content-Type", "application/json")
@@ -489,7 +490,7 @@ impl Target {
                     "/{}/controller/v1/{}/cancelAction/{}/feedback",
                     self.tenant, self.name, cancel_id
                 ))
-                .header("Authorization", &format!("TargetToken {}", self.key))
+                .header("Authorization", format!("TargetToken {}", self.key))
                 .header("Content-Type", "application/json")
                 .json_body(expected);
 
@@ -500,14 +501,14 @@ impl Target {
     /// Return the number of times the poll API has been called by the client.
     pub fn poll_hits(&self) -> usize {
         let mock = Mock::new(self.poll.get(), &self.server);
-        mock.hits()
+        mock.calls()
     }
 
     /// Return the number of times the target configuration has been uploaded by the client.
     pub fn config_data_hits(&self) -> usize {
         self.config_data.borrow().as_ref().map_or(0, |m| {
             let mock = Mock::new(m.mock, &self.server);
-            mock.hits()
+            mock.calls()
         })
     }
 
@@ -515,7 +516,7 @@ impl Target {
     pub fn deployment_hits(&self) -> usize {
         self.deployment.borrow().as_ref().map_or(0, |m| {
             let mock = Mock::new(m.mock, &self.server);
-            mock.hits()
+            mock.calls()
         })
     }
 
@@ -523,7 +524,7 @@ impl Target {
     pub fn cancel_action_hits(&self) -> usize {
         self.cancel_action.borrow().as_ref().map_or(0, |m| {
             let mock = Mock::new(m.mock, &self.server);
-            mock.hits()
+            mock.calls()
         })
     }
 }


### PR DESCRIPTION
This adds support for the additional confirmationBase endpoint needed for the hawkbit consent flow feature: https://eclipse.dev/hawkbit/rest-api/ddi.html#tag/DDI-Root-Controller/operation/getConfirmationBaseAction

This PR builds upon #15.